### PR TITLE
Update Quarto CLI version

### DIFF
--- a/.github/workflows/publish-quarto.yml
+++ b/.github/workflows/publish-quarto.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Quarto CLI
         uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: 1.7.32
+          version: '1.4.554'
 
       - name: Render Quarto site
         run: quarto render


### PR DESCRIPTION
## Summary
- set the Quarto CLI version in the publish workflow to a valid release

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685b9009e7cc832cbe1c8cb71dd2f628